### PR TITLE
[Feat]: 유저 리뷰 컨트롤러 조회 값 없을 시 응답 데이터에 빈배열 추가

### DIFF
--- a/controllers/review.controller.js
+++ b/controllers/review.controller.js
@@ -42,7 +42,9 @@ LIMIT ?;
     const [reviews] = await db.query(sql, params);
 
     if (!reviews.length) {
-      return res.status(404).json({ success: true, lastCursor: null });
+      return res
+        .status(404)
+        .json({ success: true, reviews: [], lastCursor: null });
     }
 
     const lastCursor = reviews[reviews.length - 1].id;


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

- ✨ 주요 기능: 유저 리뷰 컨트롤러 API 수정
  - [ ] 조회 값 없을 시 응답데이터에 빈배열 추가: 
  라스트 커서 조회 시 값이 없을 때 아무 데이터도 전달하지 않으면 에러가 발생한다고 해서 값이 없을 때도 빈 배열 전달하도록 변경했습니다.

---


# 🖼️ 결과 이미지 (Screenshots)

![image](https://github.com/user-attachments/assets/dd3a1958-51d2-4e50-a2f9-cfa95cc6f36f)
---

# 📝 참고 사항 (Additional notes)

원래 조회 값이 없어도 빈 배열 전달해야 하는데 제가 구현하다가 까먹은 부분이라 다른 API들은 무한스크롤 구현에 문제 없습니다